### PR TITLE
feat(auth): simple auth scaffolding with types and endpoint installation

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -17,21 +17,24 @@ function main {
     # common
     sync "$here"/template/{package.json,.gitignore,.npmrc}
     sync "$here"/template/packages/tsconfig.base.json
-    sync "$here"/template/packages/{lib,frontend,backend}/package.json
-    sync "$here"/template/packages/{lib,frontend,backend}/tsconfig.json
-    sync "$here"/template/packages/{lib,backend}/index.ts
+    sync "$here"/template/packages/{auth,lib,frontend,backend}/package.json
+    sync "$here"/template/packages/{auth,lib,frontend,backend}/tsconfig.json
+    sync "$here"/template/packages/{auth,lib,backend}/index.ts
     sync "$here"/template/packages/frontend/index.tsx
     sync "$here"/template/.github/
     # jest
     sync "$here"/template/packages/jest.base.config.js
-    sync "$here"/template/packages/{lib,frontend,backend}/jest.config.js
-    sync "$here"/template/packages/{lib,frontend,backend}/index.test.ts
+    sync "$here"/template/packages/{auth,lib,frontend,backend}/jest.config.js
+    sync "$here"/template/packages/{auth,lib,frontend,backend}/index.test.ts
     # linting
     sync "$here"/template/{.prettierrc,.prettierignore}
     sync "$here"/template/packages/.eslintrc.base.js
-    sync "$here"/template/packages/{lib,frontend,backend}/.eslintrc.js
+    sync "$here"/template/packages/{auth,lib,frontend,backend}/.eslintrc.js
     # lib
     sync "$here"/template/packages/lib/src/
+    # auth
+    sync "$here"/template/packages/auth/lib/
+    sync "$here"/template/packages/auth/README.md
     # backend
     sync "$here"/template/Procfile
     sync "$here"/template/packages/backend/nodemon.json

--- a/template/packages/.eslintrc.base.js
+++ b/template/packages/.eslintrc.base.js
@@ -22,7 +22,7 @@ module.exports = {
     'react-hooks/rules-of-hooks': 'error',
     'react-hooks/exhaustive-deps': 'warn',
     '@typescript-eslint/no-floating-promises': 2,
-    '@typescript-eslint/require-await': 2,
+    '@typescript-eslint/require-await': 0,
     '@typescript-eslint/unbound-method': 2,
     '@typescript-eslint/no-triple-slash-reference': 0,
     '@typescript-eslint/camelcase': 0,

--- a/template/packages/auth/.eslintrc.js
+++ b/template/packages/auth/.eslintrc.js
@@ -1,0 +1,9 @@
+module.exports = {
+  extends: '../.eslintrc.base.js',
+  parserOptions: {
+    project: './tsconfig.json',
+  },
+  env: {
+    node: true,
+  },
+};

--- a/template/packages/auth/README.md
+++ b/template/packages/auth/README.md
@@ -1,0 +1,93 @@
+## the package tentatively titled "@Originate/auth"
+
+This package builds on top of `@Originate/leash` to provide endpoints that implement a common user-password authentication scheme on user-facing websites. The endpoints are documented below.
+
+### POST `/api/auth/login`
+
+``` tsx
+export interface LoginRequest {
+  id: string;
+  password: string;
+}
+
+export interface LoginGood<TUser> {
+  ok: true;
+  id: string;
+  user: TUser;
+  token: string;
+}
+
+export type LoginBad = {ok: false; key: string; error: string};
+
+export type LoginResponse<TUser> = LoginGood<TUser> | LoginBad;
+```
+
+Returns a stateless JWT token on success. This token, which will be a short alphanumeric string, authenticates further HTTP requests to the backend. Send it via an `Authorization: Bearer <token>` header. Tokens expire after a certain interval, which can be configured when the endpoints are installed (in the `@Originate/leash` sense of the word "install"). Tokens are stateless, meaning they are not stored in the backend. They are, instead, generated from an authenticated hash of the user's secret password, keyed off a key provided to the backend via its environment variables.
+
+### POST `/api/auth/signup`
+
+``` tsx
+export interface SignupRequest<TUser> {
+  user: TUser;
+  password: string;
+}
+
+export interface SignupGood {
+  ok: true;
+  id: string;
+}
+
+export type SignupBad = {ok: false; key: string; error: string};
+
+export type SignupResponse = SignupGood | SignupBad;
+```
+
+Creates a user account. The consumer of this library can decide what type the user object should be via a generic parameter `TUser`. For example, one app might want (full name, address, social-security number). Another app might want (Twitch username, Twitter username, Battle.net username). Along with providing a custom type, this library's consumers should also implement an `io-ts` Decoder for the type, so that the library can validate and parse incoming user objects.
+
+It is required to send an `Authorization: Bearer signup` header along with this request. We treat "signup" as a temporary token that authenticates an anonymous request (users who are signing up have yet to authenticate with the backend, because they are unable to yet, so they are effectively anonymous) and authorizes the request to access exactly one endpoint, which is this one, the signup endpoint. This requirement prevents trivial CSRF attacks.
+
+
+### POST `/api/auth/password-reset`
+
+``` tsx
+export interface PasswordResetRequest {
+  id: string;
+}
+
+export type PasswordResetResponse = {ok: true} | {ok: false; key: string; error: string};
+```
+
+Initiates the password-reset flow. The backend will send a one-time password-reset token along a trusted communicaton channel (usually email). The library's consumer should then implement a user-facing frontend route that is able to send that token to the endpoint below, along with a new password.
+
+### PUT `/api/auth/password`
+
+``` tsx
+export interface PasswordRequest {
+  token: string;
+  password: string;
+}
+
+export type PasswordResponse = {ok: true} | {ok: false; key: string; error: string};
+```
+
+A successful invocation of this endpoint will "use up" the password-reset token, and render that token useless.
+
+### Keyed errors
+
+Errors from these endpoints are *keyed*, meaning they include a human-friendly English error string as well as a short, symbolic string for the frontend to test on. For example, `{ok: false, key: "passwordTooShort", error: "Passwords must be at least 10 characters long."}`.
+
+### Persistent storage
+
+For this library to work, it needs to read and write from persistent storage. The library's users are asked to implement the following interface, and to pass it into the library during endpoint installation.
+
+``` tsx
+// This interface is tentative
+interface Persistent<TSignup, TLogin> {
+  async createID(signup: TSignup): Promise<TSignup>
+  async authenticateID(id: string, password: string): Promise<TLogin | 'missing' | 'rate-limited'>
+  async findID(id: string): Promise<TLogin | 'missing'>
+  async resetID(id: string, password: string): Promise<'ok' | 'missing'>
+}
+```
+
+The interface is designed so that these functions are simple enough to implement with one or two SQL queries.

--- a/template/packages/auth/index.test.ts
+++ b/template/packages/auth/index.test.ts
@@ -1,0 +1,1 @@
+it('works', () => expect(1).toEqual(1));

--- a/template/packages/auth/index.ts
+++ b/template/packages/auth/index.ts
@@ -1,0 +1,24 @@
+/// This library implements a stateless authentication scheme based on JSON
+/// tokens. Once logged in, web and mobile clients should pass the JSON token
+/// via an `Authorization: Bearer <token>` header. To prevent CSRF attacks,
+/// place all endpoints that mutate the backend's state behind an Authorization
+/// header check.
+
+import * as Router from '@Originate/leash';
+
+export * from './lib/backend';
+export * from './lib/decoders';
+import * as types from './lib/types';
+
+//////////////////////////////////////// The rest
+
+export function makeRouter<TSignup, TLogin>() {
+  return {
+    signup: Router.post<types.SignupResponse, types.SignupRequest<TSignup>>('/api/auth/signup'),
+    login: Router.post<types.LoginResponse<TLogin>, types.LoginRequest>('/api/auth/login'),
+    password: Router.put<types.PasswordResponse, types.PasswordRequest>('/api/auth/password'),
+    ['password-reset']: Router.post<types.PasswordResetResponse, types.PasswordResetRequest>(
+      '/api/auth/password-reset',
+    ),
+  };
+}

--- a/template/packages/auth/index.ts
+++ b/template/packages/auth/index.ts
@@ -17,8 +17,6 @@ export function makeRouter<TSignup, TLogin>() {
     signup: Router.post<types.SignupResponse, types.SignupRequest<TSignup>>('/api/auth/signup'),
     login: Router.post<types.LoginResponse<TLogin>, types.LoginRequest>('/api/auth/login'),
     password: Router.put<types.PasswordResponse, types.PasswordRequest>('/api/auth/password'),
-    ['password-reset']: Router.post<types.PasswordResetResponse, types.PasswordResetRequest>(
-      '/api/auth/password-reset',
-    ),
+    passwordReset: Router.post<types.PasswordResetResponse, types.PasswordResetRequest>('/api/auth/password-reset'),
   };
 }

--- a/template/packages/auth/jest.config.js
+++ b/template/packages/auth/jest.config.js
@@ -1,0 +1,2 @@
+const base = require('../jest.base.config.js');
+module.exports = base;

--- a/template/packages/auth/lib/backend.ts
+++ b/template/packages/auth/lib/backend.ts
@@ -1,0 +1,60 @@
+import * as D from 'io-ts/lib/Decoder';
+import {isLeft} from 'fp-ts/lib/Either';
+import {Request, Response} from 'express';
+
+import {Result, bad} from '@Originate/leash';
+import * as types from './types';
+import * as decoders from './decoders';
+
+type ValidatedControllerMethod<EndpointArg, RequestType, RouteResult> = (
+  payload: EndpointArg,
+  req: RequestType,
+  res: Response,
+) => Promise<Result<RouteResult>>;
+
+function withValidation<EndpointArg, RequestKind extends Request, RouteResult>(
+  decoder: D.Decoder<EndpointArg, EndpointArg>,
+  endpoint: ValidatedControllerMethod<EndpointArg, RequestKind, RouteResult>,
+) {
+  return (req: RequestKind, res: Response) => {
+    const result = decoder.decode(req.body);
+    if (isLeft(result)) return bad(400, D.draw(result.left));
+    else return endpoint(result.right, req, res);
+  };
+}
+
+export class AuthController<TSignup, TUser> {
+  constructor(private signupDecoder: D.Decoder<unknown, TSignup>) {}
+
+  loginPOST = withValidation(
+    decoders.loginRequestDecoder,
+    async (req): Promise<Result<types.LoginResponse<TUser>>> => {
+      console.debug('>>>>>>>', req);
+      return bad(400, 'unauthorized');
+    },
+  );
+
+  signupPOST = withValidation(
+    decoders.signupRequestDecoder(this.signupDecoder),
+    async (req): Promise<Result<types.LoginResponse<TSignup>>> => {
+      console.debug('>>>>>>>>>>>>', req);
+      return bad(400, 'unauthorized');
+    },
+  );
+
+  passwordResetPOST = withValidation(
+    decoders.passwordResetRequestDecoder,
+    async (req): Promise<Result<types.PasswordResetResponse>> => {
+      console.debug('>>>>>>>>>>>>', req);
+      return bad(400, 'unauthorized');
+    },
+  );
+
+  passwordPUT = withValidation(
+    decoders.passwordRequestDecoder,
+    async (req): Promise<Result<types.PasswordResponse>> => {
+      console.debug('>>>>>>>>>>>>', req);
+      return bad(400, 'unauthorized');
+    },
+  );
+}

--- a/template/packages/auth/lib/decoders.ts
+++ b/template/packages/auth/lib/decoders.ts
@@ -1,0 +1,26 @@
+import * as D from 'io-ts/lib/Decoder';
+
+import {LoginRequest, SignupRequest, PasswordResetRequest, PasswordRequest} from './types';
+
+export const loginRequestDecoder: D.Decoder<unknown, LoginRequest> = D.type({
+  id: D.string,
+  password: D.string,
+});
+
+export function signupRequestDecoder<TUser>(
+  userDecoder: D.Decoder<unknown, TUser>,
+): D.Decoder<unknown, SignupRequest<TUser>> {
+  return D.type({
+    user: userDecoder,
+    password: D.string,
+  });
+}
+
+export const passwordResetRequestDecoder: D.Decoder<unknown, PasswordResetRequest> = D.type({
+  id: D.string,
+});
+
+export const passwordRequestDecoder: D.Decoder<unknown, PasswordRequest> = D.type({
+  token: D.string,
+  password: D.string,
+});

--- a/template/packages/auth/lib/io-ts.ts
+++ b/template/packages/auth/lib/io-ts.ts
@@ -1,0 +1,11 @@
+import {isLeft} from 'fp-ts/lib/Either';
+import * as D from 'io-ts/lib/Decoder';
+
+export function withDefault<T, U>(defaultValue: U, decoder: D.Decoder<T, U>): D.Decoder<T, U> {
+  return {
+    decode: (u) => {
+      const result = decoder.decode(u);
+      return isLeft(result) ? D.success(defaultValue) : result;
+    },
+  };
+}

--- a/template/packages/auth/lib/types.ts
+++ b/template/packages/auth/lib/types.ts
@@ -1,0 +1,48 @@
+//////////////////////////////////////// Signup
+
+export interface SignupRequest<TUser> {
+  user: TUser;
+  password: string;
+}
+
+export interface SignupGood {
+  ok: true;
+  id: string;
+}
+
+export type SignupBad = {ok: false; key: string; error: string};
+
+export type SignupResponse = SignupGood | SignupBad;
+
+//////////////////////////////////////// Login
+
+export interface LoginRequest {
+  id: string;
+  password: string;
+}
+
+export interface LoginGood<TUser> {
+  ok: true;
+  id: string;
+  user: TUser;
+  token: string;
+}
+
+export type LoginBad = {ok: false; key: string; error: string};
+
+export type LoginResponse<TUser> = LoginGood<TUser> | LoginBad;
+
+//////////////////////////////////////// Password reset
+
+export interface PasswordResetRequest {
+  id: string;
+}
+
+export type PasswordResetResponse = {ok: true} | {ok: false; key: string; error: string};
+
+export interface PasswordRequest {
+  token: string;
+  password: string;
+}
+
+export type PasswordResponse = {ok: true} | {ok: false; key: string; error: string};

--- a/template/packages/auth/package.json
+++ b/template/packages/auth/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@/auth",
+  "version": "1.0.0",
+  "scripts": {
+    "build": "true",
+    "typecheck": "echo auth && tsc -p .",
+    "typecheck:watch": "yarn typecheck --watch",
+    "lint": "eslint --cache --ext .ts .",
+    "test": "jest --maxWorkers=1"
+  },
+  "private": true,
+  "dependencies": {
+    "@Originate/leash": "^1.0.6"
+  }
+}

--- a/template/packages/auth/tsconfig.json
+++ b/template/packages/auth/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "ignored",
+    "noEmit": false
+  },
+  "exclude": [
+    "node_modules",
+    "ignored",
+    "*.config.js"
+  ]
+}

--- a/template/packages/backend/index.ts
+++ b/template/packages/backend/index.ts
@@ -30,7 +30,7 @@ function main() {
   const app = makeExpress(env, (app) => {
     authRouter.login.install(app, authController.loginPOST);
     authRouter.signup.install(app, authController.signupPOST);
-    authRouter['password-reset'].install(app, authController.passwordResetPOST);
+    authRouter.passwordReset.install(app, authController.passwordResetPOST);
     authRouter.password.install(app, authController.passwordPUT);
 
     router.ping.install(app, async (req) => {

--- a/template/packages/backend/src/utils/express.ts
+++ b/template/packages/backend/src/utils/express.ts
@@ -99,6 +99,7 @@ export const makeExpress = (env: Env, installRoutes: (app: Express) => void): Ex
   app.use('/apple-touch-icon.png', sendStaticFile('apple-touch-icon.png', 'image/png'));
   app.use('/favicon.png', sendStaticFile('favicon.png', 'image/png'));
   app.use('/robots.txt', sendStaticFile('robots.txt', 'text/plain'));
+  app.use('/api/*', (_, res) => res.sendStatus(404));
   app.use('*', sendStaticFile('index.html', 'text/html; charset=UTF-8'));
   return app;
 };

--- a/template/packages/lib/index.ts
+++ b/template/packages/lib/index.ts
@@ -1,5 +1,1 @@
-export {router} from './src/routes';
-
-export enum Hello {
-  world = 'world',
-}
+export {authRouter, router, UserSignup, User} from './src/routes';

--- a/template/packages/lib/src/routes.ts
+++ b/template/packages/lib/src/routes.ts
@@ -1,5 +1,17 @@
 import * as Router from '@Originate/leash';
+import * as Auth from '@/auth';
+
+export interface UserSignup {
+  name: string;
+}
+
+export interface User extends UserSignup {
+  occupation: string;
+}
+
+export const authRouter = Auth.makeRouter<UserSignup, User>();
 
 export const router = {
+  ...authRouter,
   ping: Router.get<{mood: string}, {mood: string}>('/api/ping', ({mood}: {mood: string}) => `/api/ping?mood=${mood}`),
 };


### PR DESCRIPTION
This PR scaffolds the types and endpoints required for four `/api/auth/...` endpoints, setting up the types and endpoint installation. The next PR will introduce a `Persistent` interface so that the endpoints actually do something, i.e. make queries to a SQL or SQLite database.

[See rendered documentation for more details](https://github.com/Originate/create-originate-app/blob/hl/auth/template/packages/auth/README.md)

The motivation behind this package was to refactor the common authentication scheme we implemented on Chief and Vibecheq into its own library, which had few dependencies on other libraries in the NPM ecosystem and was compatible with `@Originate/leash`.

## Side notes

* The package currently lives as a workspace of the `create-originate-app` template, but conceivably becomes its own repository in the future, at which point it could live as another GitHub package, like `@Originate/leash` does