### PR TITLE
github ci: feat(e2e tests)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,32 @@
+name: workflows/e2e.yml
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+      - deploy/production
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: GitHub Packages magic
+      env:
+        TOKEN: ${{ secrets.MACHINE_GITHUB_PACKAGES_TOKEN }}
+      run: |
+        cat >~/.npmrc <<EOF
+        //npm.pkg.github.com/:_authToken=$TOKEN
+        @Originate:registry=https://npm.pkg.github.com
+        always-auth=true
+        EOF
+    - name: apt-get
+      run: |
+        sudo apt-get -y install zsh
+    - name: Simulate npx
+      run: |
+        cd ..
+        mv create-originate-app/ vendor/
+        ./vendor/bootstrap
+        yarn typecheck
+        yarn lint


### PR DESCRIPTION
This simulates a run of `npx github:Originate/create-originate-app hello-world` on GitHub CI. It's mostly meant to test the `sync` shell script. It's "end-to-end," in the sense that we are simulating a user who is downloading and running COA for the first time.