### PR TITLE
backend: upgrade(leash, 2.0.x)

### DIFF
--- a/template/packages/auth/index.ts
+++ b/template/packages/auth/index.ts
@@ -14,9 +14,9 @@ import * as types from './lib/types';
 
 export function makeRouter<TSignup, TLogin>() {
   return {
-    signup: Router.post<types.SignupResponse, types.SignupRequest<TSignup>>('/api/auth/signup'),
-    login: Router.post<types.LoginResponse<TLogin>, types.LoginRequest>('/api/auth/login'),
-    password: Router.put<types.PasswordResponse, types.PasswordRequest>('/api/auth/password'),
-    passwordReset: Router.post<types.PasswordResetResponse, types.PasswordResetRequest>('/api/auth/password-reset'),
+    signup: Router.post<types.SignupRequest<TSignup>, types.SignupResponse>('/api/auth/signup'),
+    login: Router.post<types.LoginRequest, types.LoginResponse<TLogin>>('/api/auth/login'),
+    password: Router.put<types.PasswordRequest, types.PasswordResponse>('/api/auth/password'),
+    passwordReset: Router.post<types.PasswordResetRequest, types.PasswordResetResponse>('/api/auth/password-reset'),
   };
 }

--- a/template/packages/auth/lib/backend.ts
+++ b/template/packages/auth/lib/backend.ts
@@ -16,7 +16,7 @@ function withValidation<EndpointArg, RequestKind extends Request, RouteResult>(
   decoder: D.Decoder<EndpointArg, EndpointArg>,
   endpoint: ValidatedControllerMethod<EndpointArg, RequestKind, RouteResult>,
 ) {
-  return (req: RequestKind, res: Response) => {
+  return async (req: RequestKind, res: Response) => {
     const result = decoder.decode(req.body);
     if (isLeft(result)) return bad(400, D.draw(result.left));
     else return endpoint(result.right, req, res);

--- a/template/packages/auth/package.json
+++ b/template/packages/auth/package.json
@@ -10,6 +10,6 @@
   },
   "private": true,
   "dependencies": {
-    "@Originate/leash": "^1.0.6"
+    "@Originate/leash": "^2.0.1"
   }
 }

--- a/template/packages/backend/package.json
+++ b/template/packages/backend/package.json
@@ -16,7 +16,7 @@
   },
   "private": true,
   "dependencies": {
-    "@Originate/leash": "^1.0.6",
+    "@Originate/leash": "^2.0.1",
     "@types/compression": "^1.7.0",
     "@types/cors": "^2.8.7",
     "@types/express": "^4.17.7",

--- a/template/packages/frontend/modules/hello/index.tsx
+++ b/template/packages/frontend/modules/hello/index.tsx
@@ -7,7 +7,7 @@ import {Counter} from '@/frontend/modules/counter';
 
 interface HelloView {
   onClick: () => void;
-  mood?: Fetch<Array<{mood: string}>>;
+  mood?: Fetch<{mood: string}>;
 }
 
 const HelloView: React.FC<HelloView> = ({onClick, mood}) => (

--- a/template/packages/frontend/modules/hello/reducer.ts
+++ b/template/packages/frontend/modules/hello/reducer.ts
@@ -6,7 +6,7 @@ export type HelloStore = {
   mood?: Fetch<Array<{mood: string}>>;
 };
 
-export type HelloAction = ActionOf<'hello/click', Fetch<Array<{mood: string}>>>;
+export type HelloAction = ActionOf<'hello/click', Fetch<{mood: string}>>;
 
 export const initialStore: HelloStore = {};
 
@@ -24,8 +24,8 @@ export function dispatch(this: IDispatch) {
     onClick: async () => {
       try {
         this.dispatch({key: 'hello/click', state: 'loading'});
-        const moods = await router.ping.client({mood: 'big'});
-        this.dispatch({key: 'hello/click', state: 'good', data: moods});
+        const mood = await router.ping.client({mood: 'big'});
+        this.dispatch({key: 'hello/click', state: 'good', data: mood});
       } catch (e) {
         this.dispatch({key: 'hello/click', state: 'bad', error: e.toString()});
       }

--- a/template/packages/frontend/modules/hello/reducer.ts
+++ b/template/packages/frontend/modules/hello/reducer.ts
@@ -3,7 +3,7 @@ import {IDispatch} from '@/frontend/src/store';
 import {ActionOf, Fetch} from '@/frontend/lib';
 
 export type HelloStore = {
-  mood?: Fetch<Array<{mood: string}>>;
+  mood?: Fetch<{mood: string}>;
 };
 
 export type HelloAction = ActionOf<'hello/click', Fetch<{mood: string}>>;

--- a/template/packages/lib/package.json
+++ b/template/packages/lib/package.json
@@ -10,6 +10,6 @@
   },
   "private": true,
   "dependencies": {
-    "@Originate/leash": "^1.0.6"
+    "@Originate/leash": "^2.0.1"
   }
 }

--- a/template/yarn.lock
+++ b/template/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@Originate/leash@^1.0.6":
-  version "1.0.6"
-  resolved "https://npm.pkg.github.com/download/@Originate/leash/1.0.6/f0a55175b6f5390f541592fb395817b323149d571dc076e2cef9a5dbbebdf3cc#7f60cb5bf59b40fad77cf89694d8c16c51607760"
-  integrity sha512-Bvob0pYOEEgi6hFgBmIKeEhJRKHH011BmVFqF7TiZFgVmIlLIouvtUXzN5NmoOe0TGnw25Hwa/EqE8z2pq0rQg==
+"@Originate/leash@^2.0.1":
+  version "2.0.1"
+  resolved "https://npm.pkg.github.com/download/@Originate/leash/2.0.1/25b751cb3243e84ed5cea357bd39a635af5601fcfb206be75d6c0304d0256e8f#398fd9eb1c0a0f31dee8492124f92a962ebc559e"
+  integrity sha512-/EpCVShQJ8eolLXmcS76FfVKRtblT323ar3yhqGmVx8WH3k+kWf8uYo6p6ejh20Y3PXhC+9GixnMeHYgFOIzuQ==
 
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.10.4":
   version "7.10.4"


### PR DESCRIPTION
`@Originate/leash`v2.0 brings with it:

- More ergonomic types
- GET endpoints no longer forced to return `Array<_>`