### PR TITLE
backend: feat(crypto library)

### DIFF
--- a/template/packages/backend/lib/crypto.test.ts
+++ b/template/packages/backend/lib/crypto.test.ts
@@ -1,0 +1,34 @@
+import {CryptoService} from './crypto';
+import * as RawTime from '@/backend/lib/time';
+
+const crypto = new CryptoService(3);
+const Time = RawTime as jest.Mocked<typeof RawTime>;
+
+jest.mock('@/backend/lib/time', () => ({now: jest.fn(), addDays: jest.fn()}));
+
+beforeEach(() => jest.resetAllMocks());
+
+describe('session tokens', () => {
+  it('round-trips', async () => {
+    Time.now.mockImplementation(() => new Date());
+    Time.addDays.mockImplementation(() => new Date(+new Date() + 999));
+    const token = crypto.mintSessionToken('user@example.com');
+    const verification = crypto.verifySessionToken(token);
+    expect(verification).toBe(true);
+  });
+
+  it('expires', async () => {
+    Time.now.mockImplementation(() => new Date());
+    Time.addDays.mockImplementation(() => new Date());
+    const token = crypto.mintSessionToken('user@example.com');
+    const verification = crypto.verifySessionToken(token);
+    expect(verification).toBe(false);
+  });
+});
+
+describe('password digests', () => {
+  it('round-trips', async () => {
+    const key = await crypto.passwordKeyDerive('password');
+    expect(await crypto.verifyPassword({plaintext: 'password', digest: key})).toBe(true);
+  });
+});

--- a/template/packages/backend/lib/crypto.ts
+++ b/template/packages/backend/lib/crypto.ts
@@ -1,0 +1,68 @@
+import Scrypt from 'scrypt-kdf';
+import nacl from 'tweetnacl';
+
+import * as Time from '@/backend/lib/time';
+
+interface KeyPair {
+  publicKey: Uint8Array;
+  secretKey: Uint8Array;
+}
+
+interface Message {
+  id: string;
+  exp: number;
+}
+
+function bytesOfUTF8(s: string) {
+  return Uint8Array.from(Buffer.from(s, 'utf8'));
+}
+
+function utf8OfBytes(bytes: Uint8Array) {
+  return Buffer.from(bytes).toString('utf8');
+}
+
+function hexOfBytes(bytes: Uint8Array) {
+  return Buffer.from(bytes).toString('hex');
+}
+
+function bytesOfHex(hex: string) {
+  return Uint8Array.from(Buffer.from(hex, 'hex'));
+}
+
+export class CryptoService {
+  private keyPair: KeyPair;
+
+  constructor(private expirationInDays: number) {
+    this.keyPair = nacl.sign.keyPair();
+  }
+
+  verifySessionToken(token: string): boolean {
+    const opened: Uint8Array | null = nacl.sign.open(bytesOfHex(token), this.keyPair.publicKey);
+    if (opened && (JSON.parse(utf8OfBytes(opened)) as Message).exp > +Time.now()) {
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  mintSessionToken(id: string): string {
+    if (typeof id !== 'string') throw new Error('id not string');
+    if (!id.length) throw new Error('id empty');
+    const message: Message = {id, exp: +Time.addDays(Time.now(), this.expirationInDays)};
+    return hexOfBytes(nacl.sign(bytesOfUTF8(JSON.stringify(message)), this.keyPair.secretKey));
+  }
+
+  async passwordKeyDerive(password: string): Promise<string> {
+    // {logN: 15} comes from https://blog.filippo.io/the-scrypt-parameters/
+    const key = await Scrypt.kdf(password, {logN: 15, r: 8, p: 1});
+    return key.toString('hex');
+  }
+
+  async verifyPassword(pair: {plaintext: string; digest: string}): Promise<boolean> {
+    try {
+      return Scrypt.verify(Buffer.from(pair.digest, 'hex'), pair.plaintext);
+    } catch (e) {
+      return false;
+    }
+  }
+}

--- a/template/packages/backend/lib/time.ts
+++ b/template/packages/backend/lib/time.ts
@@ -1,0 +1,9 @@
+export function addDays(date: Date, days: number): Date {
+  const result = new Date(date);
+  result.setDate(result.getDate() + days);
+  return result;
+}
+
+export function now(): Date {
+  return new Date();
+}

--- a/template/packages/backend/package.json
+++ b/template/packages/backend/package.json
@@ -27,7 +27,9 @@
     "fp-ts": "^2.8.1",
     "io-ts": "^2.2.10",
     "log4js": "^6.3.0",
+    "scrypt-kdf": "^2.0.1",
     "ts-node": "^8.10.2",
-    "tsconfig-paths": "^3.9.0"
+    "tsconfig-paths": "^3.9.0",
+    "tweetnacl": "^1.0.3"
   }
 }

--- a/template/yarn.lock
+++ b/template/yarn.lock
@@ -7965,6 +7965,11 @@ schema-utils@^2.6.5, schema-utils@^2.7.0, schema-utils@^2.7.1:
     ajv "^6.12.4"
     ajv-keywords "^3.5.2"
 
+scrypt-kdf@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/scrypt-kdf/-/scrypt-kdf-2.0.1.tgz#3355224c52d398331b2cbf2b70a7be26b52c53e6"
+  integrity sha512-dMhpgBVJPDWZP5erOCwTjI6oAO9hKhFAjZsdSQ0spaWJYHuA/wFNF2weQQfsyCIk8eNKoLfEDxr3zAtM+gZo0Q==
+
 select-hose@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/select-hose/-/select-hose-2.0.0.tgz#625d8658f865af43ec962bfc376a37359a4994ca"
@@ -8864,6 +8869,11 @@ tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   version "0.14.5"
   resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"
   integrity sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=
+
+tweetnacl@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-1.0.3.tgz#ac0af71680458d8a6378d0d0d050ab1407d35596"
+  integrity sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==
 
 type-check@^0.4.0, type-check@~0.4.0:
   version "0.4.0"


### PR DESCRIPTION
This implements some basic crypto primitives for authentication:

- password digests (so we can store a salted, scrypted password in the database) 
- session token minting (using cryptographic signatures)

Care was taken to avoid the `crypto` library that comes with Node. That library has a dangerous interface for scrypt (takes a salt, even though scrypt algorithm is explicitly designed to generate a salt), and it lacks ed25519 signatures. Instead, we lean on two reliable libraries: `scrypt-kdf` and `tweetnacl`.