### PR TITLE
backend: implement a default auth strategy with postgres

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -9,6 +9,7 @@
     "test": "yarn workspaces run test",
     "lint": "yarn workspaces run lint",
     "fix": "yarn workspaces run lint --fix",
+    "migrate": "yarn workspace @/backend migrate",
     "run:heroku": "yarn workspace @/backend run:heroku"
   },
   "workspaces": [

--- a/template/packages/auth/index.ts
+++ b/template/packages/auth/index.ts
@@ -8,6 +8,7 @@ import * as Router from '@Originate/leash';
 
 export * from './lib/backend';
 export * from './lib/decoders';
+export * from './lib/types';
 import * as types from './lib/types';
 
 //////////////////////////////////////// The rest

--- a/template/packages/auth/lib/backend.ts
+++ b/template/packages/auth/lib/backend.ts
@@ -2,9 +2,24 @@ import * as D from 'io-ts/lib/Decoder';
 import {isLeft} from 'fp-ts/lib/Either';
 import {Request, Response} from 'express';
 
-import {Result, bad} from '@Originate/leash';
+import {Result, bad, good} from '@Originate/leash';
 import * as types from './types';
 import * as decoders from './decoders';
+
+export interface AuthStrategy<TSignup, TUser> {
+  signupDecoder: D.Decoder<unknown, TSignup>;
+  createUser(
+    user: TSignup,
+    passwordDigest: Buffer,
+  ): Promise<{ok: true; id: string} | {ok: false; key: string; error: string}>;
+  authenticate(id: string): Promise<{ok: true; passwordDigest: Buffer; user: TUser} | {ok: false}>;
+}
+
+export interface AuthCrypto {
+  mintSessionToken(id: string, expiration: {days: number}): string;
+  passwordKeyDerive(password: string): Promise<Buffer>;
+  verifyPassword(pair: {plaintext: string; digest: Buffer}): Promise<boolean>;
+}
 
 type ValidatedControllerMethod<EndpointArg, RequestType, RouteResult> = (
   payload: EndpointArg,
@@ -24,21 +39,35 @@ function withValidation<EndpointArg, RequestKind extends Request, RouteResult>(
 }
 
 export class AuthController<TSignup, TUser> {
-  constructor(private signupDecoder: D.Decoder<unknown, TSignup>) {}
+  constructor(private strategy: AuthStrategy<TSignup, TUser>, private crypto: AuthCrypto) {}
 
   loginPOST = withValidation(
     decoders.loginRequestDecoder,
     async (req): Promise<Result<types.LoginResponse<TUser>>> => {
-      console.debug('>>>>>>>', req);
-      return bad(400, 'unauthorized');
+      const result = await this.strategy.authenticate(req.id);
+      if (result.ok && (await this.crypto.verifyPassword({plaintext: req.password, digest: result.passwordDigest}))) {
+        return good({
+          ok: true,
+          id: req.id,
+          user: result.user,
+          token: this.crypto.mintSessionToken(req.id, {days: 3}),
+        });
+      } else {
+        return bad(400, 'unauthorized', 'Incorrect username or password');
+      }
     },
   );
 
   signupPOST = withValidation(
-    decoders.signupRequestDecoder(this.signupDecoder),
-    async (req): Promise<Result<types.LoginResponse<TSignup>>> => {
-      console.debug('>>>>>>>>>>>>', req);
-      return bad(400, 'unauthorized');
+    decoders.signupRequestDecoder(this.strategy.signupDecoder),
+    async (req): Promise<Result<types.SignupResponse>> => {
+      const digest = await this.crypto.passwordKeyDerive(req.password);
+      const result = await this.strategy.createUser(req.user, digest);
+      if (result.ok) {
+        return good({ok: true, id: result.id});
+      } else {
+        return bad(400, result.key, result.error);
+      }
     },
   );
 

--- a/template/packages/auth/package.json
+++ b/template/packages/auth/package.json
@@ -10,6 +10,6 @@
   },
   "private": true,
   "dependencies": {
-    "@Originate/leash": "^2.1.3"
+    "@Originate/leash": "^2.1.4"
   }
 }

--- a/template/packages/backend/lib/crypto.test.ts
+++ b/template/packages/backend/lib/crypto.test.ts
@@ -1,7 +1,7 @@
 import {CryptoService} from './crypto';
 import * as RawTime from '@/backend/lib/time';
 
-const crypto = new CryptoService(3);
+const crypto = new CryptoService();
 const Time = RawTime as jest.Mocked<typeof RawTime>;
 
 jest.mock('@/backend/lib/time', () => ({now: jest.fn(), addDays: jest.fn()}));
@@ -12,7 +12,7 @@ describe('session tokens', () => {
   it('round-trips', async () => {
     Time.now.mockImplementation(() => new Date());
     Time.addDays.mockImplementation(() => new Date(+new Date() + 999));
-    const token = crypto.mintSessionToken('user@example.com');
+    const token = crypto.mintSessionToken('user@example.com', {days: 1});
     const verification = crypto.verifySessionToken(token);
     expect(verification).toBe(true);
   });
@@ -20,7 +20,7 @@ describe('session tokens', () => {
   it('expires', async () => {
     Time.now.mockImplementation(() => new Date());
     Time.addDays.mockImplementation(() => new Date());
-    const token = crypto.mintSessionToken('user@example.com');
+    const token = crypto.mintSessionToken('user@example.com', {days: 1});
     const verification = crypto.verifySessionToken(token);
     expect(verification).toBe(false);
   });

--- a/template/packages/backend/migrations/1600920593481_auth.js
+++ b/template/packages/backend/migrations/1600920593481_auth.js
@@ -8,17 +8,17 @@ exports.shorthands = {
 
 exports.up = (pgm) => {
   pgm.createTable('auth', {
-    id: {type: 'text', notNull: true},
-    passwordDigest: {type: 'bytea', notNull: true},
+    id: {type: 'text', notNull: true, primaryKey: true},
+    password_digest: {type: 'bytea', notNull: true},
     createdAt: 'createdAt',
   });
-  pgm.createTable('keyValue', {
-    key: {type: 'text', notNull: true},
+  pgm.createTable('key_value', {
+    key: {type: 'text', notNull: true, primaryKey: true},
     value: {type: 'jsonb', notNull: true},
   });
 };
 
 exports.down = (pgm) => {
   pgm.dropTable('auth');
-  pgm.dropTable('keyValue');
+  pgm.dropTable('key_value');
 };

--- a/template/packages/backend/package.json
+++ b/template/packages/backend/package.json
@@ -17,7 +17,7 @@
   },
   "private": true,
   "dependencies": {
-    "@Originate/leash": "^2.1.3",
+    "@Originate/leash": "^2.1.4",
     "@types/compression": "^1.7.0",
     "@types/cors": "^2.8.7",
     "@types/express": "^4.17.7",

--- a/template/packages/backend/src/authStrategy.ts
+++ b/template/packages/backend/src/authStrategy.ts
@@ -1,0 +1,59 @@
+import {QueryResult} from 'pg';
+import * as D from 'io-ts/lib/Decoder';
+
+import {Env} from '@/backend/src/env';
+import {DB} from '@/backend/src/db';
+import {UserSignup, User} from '@/lib';
+
+namespace Rows {
+  export interface Auth {
+    id: string;
+    password_digest: Buffer;
+  }
+}
+
+export class AuthStrategy {
+  constructor(_env: Env, private db: DB) {}
+
+  signupDecoder: D.Decoder<unknown, UserSignup> = D.type({
+    name: D.string,
+    email: D.string,
+  });
+
+  async createUser(
+    user: UserSignup,
+    passwordDigest: Buffer,
+  ): Promise<{ok: true; id: string} | {ok: false; key: string; error: string}> {
+    const query = `
+INSERT INTO auth(id, password_digest)
+VALUES ($1, $2)
+ON CONFLICT (id) DO NOTHING
+`;
+    return await this.db.withClient(async (client) => {
+      const answer = await client.query(query, [user.email, passwordDigest]);
+      if (answer.rowCount === 0) {
+        return {ok: false, key: 'duplicate', error: 'User with this email already exists'};
+      } else {
+        return {ok: true, id: user.email};
+      }
+    });
+  }
+
+  async authenticate(
+    id: string,
+  ): Promise<{ok: true; passwordDigest: Buffer; user: User} | {ok: false; key: string; error: string}> {
+    return await this.db.withClient(async (client) => {
+      const query = 'SELECT * FROM auth WHERE id = $1';
+      const answer: QueryResult<Rows.Auth> = await client.query(query, [id]);
+      if (answer.rows.length > 0) {
+        return {
+          ok: true,
+          passwordDigest: answer.rows[0].password_digest,
+          user: {email: answer.rows[0].id, name: 'fixme', occupation: 'fixme'},
+        };
+      } else {
+        return {ok: false, key: 'unauthorized', error: 'Incorrect username or password'};
+      }
+    });
+  }
+}

--- a/template/packages/backend/src/conductor.ts
+++ b/template/packages/backend/src/conductor.ts
@@ -1,15 +1,12 @@
 import {UserSignup, User} from '@/lib';
 import * as Auth from '@/auth';
-import * as D from 'io-ts/lib/Decoder';
 
 import {makeExpress} from '@/backend/src/utils';
 import {parseEnv} from '@/backend/src/env';
 import {App} from '@/backend/src/app';
 import {DB} from '@/backend/src/db';
-
-const signupDecoder: D.Decoder<unknown, UserSignup> = D.type({
-  name: D.string,
-});
+import {AuthStrategy} from '@/backend/src/authStrategy';
+import {CryptoService} from '@/backend/lib/crypto';
 
 function makeEnv() {
   const env = parseEnv();
@@ -27,8 +24,10 @@ function makeEnv() {
 
 export class Conductor {
   env = makeEnv();
-  authController = new Auth.AuthController<UserSignup, User>(signupDecoder);
   db = new DB(this.env);
+  cryptoService = new CryptoService();
+  authStrategy = new AuthStrategy(this.env, this.db);
+  authController = new Auth.AuthController<UserSignup, User>(this.authStrategy, this.cryptoService);
 
   async listen() {
     await this._testDB();

--- a/template/packages/frontend/modules/authDemo/index.tsx
+++ b/template/packages/frontend/modules/authDemo/index.tsx
@@ -1,0 +1,65 @@
+import * as React from 'react';
+import {isGood, isBad, isLoading} from '@/frontend/lib';
+import {useStore, useDispatch} from '@/frontend/src/components/contexts';
+
+import {AuthDemoStore} from './reducer';
+
+const AuthDemoView: React.FC<{
+  store: AuthDemoStore;
+  onSignUp: (e: React.FormEvent<HTMLFormElement>) => void;
+  onLogIn: (e: React.FormEvent<HTMLFormElement>) => void;
+}> = ({store, onSignUp, onLogIn}) => (
+  <>
+    <p>
+      <code>create-originate-app</code> comes with a simple stateless authentication system that persists to Postgres.
+      For this to work, you will need to run <code>yarn migrate up 100</code> first.
+    </p>
+    <details>
+      <summary>Sign up</summary>
+      <pre>
+        {isLoading(store.signup, () => 'loading...')}
+        {isBad(store.signup, (error) => `Unexpected error occurred: ${error}`)}
+        {isGood(store.signup, (data) => JSON.stringify(data, null, 2))}
+      </pre>
+      <form onSubmit={onSignUp} autoComplete="off">
+        <input placeholder="email" type="email" />
+        <input placeholder="password" type="password" />
+        <input placeholder="confirm" type="password" />
+        <input type="submit" value="Sign up" />
+      </form>
+    </details>
+    <details>
+      <summary>Log in</summary>
+      <pre>
+        {isLoading(store.login, () => 'loading...')}
+        {isBad(store.login, (error) => `Unexpected error occurred: ${error}`)}
+        {isGood(store.login, (data) => JSON.stringify(data, null, 2))}
+      </pre>
+      <form onSubmit={onLogIn} autoComplete="off">
+        <input placeholder="email" type="email" />
+        <input placeholder="password" type="password" />
+        <input type="submit" value="Log in" />
+      </form>
+    </details>
+  </>
+);
+
+export const AuthDemo: React.FC<{}> = () => {
+  const store = useStore().authDemo;
+  const dispatch = useDispatch();
+  return (
+    <AuthDemoView
+      store={store}
+      onSignUp={async (e) => {
+        e.preventDefault();
+        const [email, password, confirm] = (Array.from(e.currentTarget.elements) as unknown) as HTMLInputElement[];
+        await dispatch.authDemo.onSignUp(email.value, password.value, confirm.value);
+      }}
+      onLogIn={async (e) => {
+        e.preventDefault();
+        const [email, password] = (Array.from(e.currentTarget.elements) as unknown) as HTMLInputElement[];
+        await dispatch.authDemo.onLogIn(email.value, password.value);
+      }}
+    />
+  );
+};

--- a/template/packages/frontend/modules/authDemo/reducer.ts
+++ b/template/packages/frontend/modules/authDemo/reducer.ts
@@ -1,0 +1,59 @@
+import {LoginResponse, SignupResponse} from '@/auth';
+import {router, User} from '@/lib';
+import {IDispatch} from '@/frontend/src/store';
+import {ActionOf, Fetch} from '@/frontend/lib';
+
+export type AuthDemoStore = {
+  signup?: Fetch<{}>;
+  login?: Fetch<{}>;
+};
+
+export type AuthDemoAction =
+  | ActionOf<'authDemo/signUp', Fetch<SignupResponse>>
+  | ActionOf<'authDemo/logIn', Fetch<LoginResponse<User>>>;
+
+export const initialStore: AuthDemoStore = {};
+
+export const reducer = (prev: AuthDemoStore, action: AuthDemoAction): AuthDemoStore => {
+  switch (action.key) {
+    case 'authDemo/signUp':
+      return {...prev, signup: action};
+    case 'authDemo/logIn':
+      return {...prev, login: action};
+    default:
+      return prev;
+  }
+};
+
+export function dispatch(this: IDispatch) {
+  return {
+    onSignUp: async (email: string, password: string, confirm: string) => {
+      if (password === confirm && password.length >= 10) {
+        try {
+          this.dispatch({key: 'authDemo/signUp', state: 'loading'});
+          const result = await router.signup.client({user: {email, name: 'howdy'}, password});
+          this.dispatch({key: 'authDemo/signUp', state: 'good', data: result});
+        } catch (e) {
+          this.dispatch({key: 'authDemo/signUp', state: 'bad', error: e.toString()});
+        }
+      } else if (password !== confirm) {
+        this.dispatch({key: 'authDemo/signUp', state: 'bad', error: 'Password and confirmation do not match'});
+      } else if (password.length < 10) {
+        this.dispatch({
+          key: 'authDemo/signUp',
+          state: 'bad',
+          error: 'Password must be at least 10 characters, even for a silly demo',
+        });
+      }
+    },
+    onLogIn: async (email: string, password: string) => {
+      try {
+        this.dispatch({key: 'authDemo/logIn', state: 'loading'});
+        const result = await router.login.client({id: email, password});
+        this.dispatch({key: 'authDemo/logIn', state: 'good', data: result});
+      } catch (e) {
+        this.dispatch({key: 'authDemo/logIn', state: 'bad', error: e.toString()});
+      }
+    },
+  };
+}

--- a/template/packages/frontend/modules/hello/index.tsx
+++ b/template/packages/frontend/modules/hello/index.tsx
@@ -1,23 +1,27 @@
 import * as React from 'react';
+import styled from 'styled-components';
 
 import {Fetch, isGood, isBad, isLoading} from '@/frontend/lib';
 import {useStore, useDispatch} from '@/frontend/src/components/contexts';
 
 import {Counter} from '@/frontend/modules/counter';
+import {AuthDemo} from '@/frontend/modules/authDemo';
 
 interface HelloView {
   onClick: () => void;
   mood?: Fetch<{mood: string}>;
 }
 
+const Term = styled.dt`
+  font-weight: bold;
+`;
+
 const HelloView: React.FC<HelloView> = ({onClick, mood}) => (
   <div>
     <h1>Hello, Again</h1>
     <p>Some things to try next:</p>
     <dl>
-      <dt>
-        <strong>Talk to the backend</strong>
-      </dt>
+      <Term>Talk to the backend</Term>
       <dd>
         <button onClick={onClick}>Talk to the backend</button>
         <pre>
@@ -26,43 +30,35 @@ const HelloView: React.FC<HelloView> = ({onClick, mood}) => (
           {isGood(mood, (data) => JSON.stringify(data))}
         </pre>
       </dd>
-      <dt>
-        <strong>Typecheck</strong>
-      </dt>
+      <Term>Typecheck</Term>
       <dd>
-        Run <code>yarn typecheck:watch</code> or <code>yarn tw</code> (<em>ooh, aah</em>){' '}
+        Run <code>yarn typecheck:watch</code> or <code>yarn tw</code> (<em>ooh, aah</em>)
       </dd>
-      <dt>
-        <strong>Hot module reloading</strong>
-      </dt>
+      <Term>Hot module reloading</Term>
       <dd>
-        Modify <code>src/components/hello.tsx</code> and watch the changes happen live here{' '}
+        Modify <code>src/components/hello.tsx</code> and watch the changes happen live here
       </dd>
-      <dt>
-        <strong>Continuous integration</strong>
-      </dt>
+      <Term>Continuous integration</Term>
       <dd>Push to a GitHub repo to run the Action </dd>
-      <dt>
-        <strong>Heroku</strong>{' '}
-      </dt>
+      <Term>Heroku </Term>
       <dd>
-        Deploy to Heroku with <code>./vendor/heroku [name of heroku app]</code>{' '}
+        Deploy to Heroku with <code>./vendor/heroku [name of heroku app]</code>
       </dd>
-      <dt>
-        <strong>Set up Google Analytics and Sentry</strong>
-      </dt>
+      <Term>Set up Google Analytics and Sentry</Term>
       <dd>
         Set <code>GA_MEASUREMENT_ID</code> and <code>SENTRY_LAZY_LOADER_URL</code> in your{' '}
         <code>packages/frontend/.env</code>. For more information, see{' '}
         <a href="https://github.com/Originate/create-originate-app/blob/master/ANALYTICS.md">ANALYTICS.md</a>.
       </dd>
-      <dt>
-        <strong>Check out our module system</strong>
-      </dt>
+      <Term>Check out the module system</Term>
       <dd>
         A module is a React component coupled with its own state and reducer. Here is a counter implemented out of{' '}
         <code>./modules/counter</code>:
         <Counter />
+      </dd>
+      <Term>Check out the authentication system</Term>
+      <dd>
+        <AuthDemo />
       </dd>
     </dl>
   </div>

--- a/template/packages/frontend/src/dispatch/index.ts
+++ b/template/packages/frontend/src/dispatch/index.ts
@@ -2,6 +2,7 @@ import {Action} from '@/frontend/src/store';
 
 import * as counterModule from '@/frontend/modules/counter/reducer';
 import * as helloModule from '@/frontend/modules/hello/reducer';
+import * as authDemoModule from '@/frontend/modules/authDemo/reducer';
 
 /// The Dispatch class dispatches actions so you don't have to!
 //
@@ -22,4 +23,5 @@ export class Dispatch {
   // would be the ideal way this works.
   hello = helloModule.dispatch.call(this);
   counter = counterModule.dispatch.call(this);
+  authDemo = authDemoModule.dispatch.call(this);
 }

--- a/template/packages/frontend/src/store/types.ts
+++ b/template/packages/frontend/src/store/types.ts
@@ -1,9 +1,11 @@
 import * as counterModule from '@/frontend/modules/counter/reducer';
 import * as helloModule from '@/frontend/modules/hello/reducer';
+import * as authDemoModule from '@/frontend/modules/authDemo/reducer';
 
 export type Store = {
   hello: helloModule.HelloStore;
   counter: counterModule.CounterStore;
+  authDemo: authDemoModule.AuthDemoStore;
 };
 
-export type Action = counterModule.CounterAction | helloModule.HelloAction;
+export type Action = counterModule.CounterAction | helloModule.HelloAction | authDemoModule.AuthDemoAction;

--- a/template/packages/lib/package.json
+++ b/template/packages/lib/package.json
@@ -10,6 +10,6 @@
   },
   "private": true,
   "dependencies": {
-    "@Originate/leash": "^2.1.3"
+    "@Originate/leash": "^2.1.4"
   }
 }

--- a/template/packages/lib/src/routes.ts
+++ b/template/packages/lib/src/routes.ts
@@ -2,6 +2,7 @@ import * as Router from '@Originate/leash';
 import * as Auth from '@/auth';
 
 export interface UserSignup {
+  email: string;
   name: string;
 }
 

--- a/template/yarn.lock
+++ b/template/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@Originate/leash@^2.1.3":
-  version "2.1.3"
-  resolved "https://npm.pkg.github.com/download/@Originate/leash/2.1.3/3dd29f943798c4359f4537bcca7a0cea0eb68533d4d396e68b7797e2bcc2a9a0#43fc467db0d2c7cf51caf3a03c7023f4a21ec09d"
-  integrity sha512-yVJFINb0RIfYVDhkazMsenIf1KxmxbxetmHF8uiSnBMriQePEVpxyfUGQS3xZIr/46swPsiKl3R5wdADA0JTHQ==
+"@Originate/leash@^2.1.4":
+  version "2.1.4"
+  resolved "https://npm.pkg.github.com/download/@Originate/leash/2.1.4/0edc9b5418f1e4f1eb39625465c8010edce3fff0bd711d592e9ad8ff8c190061#4d7e1edbe9a6af96d4a577a1ecf342d4342c1b00"
+  integrity sha512-KRsRMffMmW2teymM1UevtavIZhsv7EfB1bxxCSPvz6DU8OojuG0YHGwEWK9pnFAvW1cCEJnDwzt9QmhsM+QTgQ==
 
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.10.4":
   version "7.10.4"


### PR DESCRIPTION
This ties together the last couple of PRs by implementing `/api/auth/login` and `/api/auth/signup` with INSERT/SELECT calls to the database. A little frontend demo is forthcoming!

```shell
$ http -v POST localhost:3000/api/auth/login id=hello@example.com password=hello
{
    "error": "unauthorized",
    "status": 400
}

$ http -v POST localhost:3000/api/auth/signup  password=hello user:='{"name":"howdy","email":"hello@example.com"}'
{
    "data": {
        "id": "hello@example.com",
        "ok": true
    }
}

$ http POST localhost:3000/api/auth/login id=hello@example.com password=hello
{
    "data": {
        "id": "hello@example.com",
        "ok": true,
        "token": "58204044a49368c478ec6f2f2e19a790881b1f69560e6b36e4e6cd059597144fcb32fa6a50063b5f6eeb13752cc8ff0d7a208c0e60932625e7c63575af5cb5027b226964223a2268656c6c6f406578616d706c652e636f6d222c22657870223a313630313330393631323636317d",
        "user": {
            "email": "hello@example.com",
            "name": "howdy",
        }
    }
}

$ http POST localhost:3000/api/auth/login id=hello@example.com password=badpassword
{
    "error": "unauthorized",
    "status": 400
}
```