### PR TITLE
ci: workflow to check that PR title matches conventional commit format

### DIFF
--- a/.github/workflows/semantic-pull-request.yml
+++ b/.github/workflows/semantic-pull-request.yml
@@ -1,6 +1,6 @@
 name: 'PR title matches conventional commit format'
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, edited, synchronize]
 
 jobs:

--- a/.github/workflows/semantic-pull-request.yml
+++ b/.github/workflows/semantic-pull-request.yml
@@ -1,0 +1,12 @@
+name: 'PR title matches conventional commit format'
+on:
+  pull_request_target:
+    types: [opened, edited, synchronize]
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v2.1.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The new workflow checks the format of PR titles according to [Conventional Commits](https://www.conventionalcommits.org/). This will be handy when we're ready to start pushing versioned releases - sticking to a title format will give us automatically-generated change logs, and automatic version bumping.

In short the format requires that the title have a prefix to show what kind of change it is. For example `feat: add CMS support` indicates a feature, `fix: suppress error messages in tests` indicates a bug fix. If the PR includes a breaking change it's important to include an exclamation mark like, `refactor!: drop support for Node 10`.

**Important:** When the PR is merged you need to use the "squash and merge" option, and you should use the title of the PR as the title of the new commit. (The PR title automatically populates the commit title field.) We can't check correctness of the commit title before a merge; we can only check the PR title.

    