### PR TITLE
fix: do not attempt to look up current git branch name when running CLI

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -11,7 +11,7 @@ import {
 } from "./helpers"
 import { run_yarn } from "./cmd"
 
-export async function run(args: string[], branch_name: string) {
+export async function run(args: string[], branch_name: string = "master") {
   program
     .version(getVersion())
     .command("create <project_name>", { isDefault: true })

--- a/src/create-originate-app.ts
+++ b/src/create-originate-app.ts
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 import chalk from "chalk"
 import { run } from "./app"
-import { git_branch_name } from "./cmd"
 
 const logo = () => {
   console.error(
@@ -18,8 +17,7 @@ const logo = () => {
 
 async function main() {
   logo()
-  const branch_name = git_branch_name()
-  await run(process.argv, branch_name)
+  await run(process.argv)
 }
 
 main()

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -53,23 +53,15 @@ export const BACKEND_REGEXP = /PORT=\d+/g
 export const DATABASE_URL_REGEXP = /DATABASE_URL=postgres:\/\/postgres:password@localhost\/postgres/
 export const README_REGEXP = /@replaceme/
 
-const isTest = (): boolean => {
-  return process.env.NODE_ENV === "test"
-}
-
-function getTemplatePath(branch_name: string): string {
-  if (isTest()) {
-    return `github:originate/create-originate-app/template#${branch_name}`
-  } else {
-    return "github:originate/create-originate-app/template#master"
-  }
+function getTemplateUri(branch_name: string): string {
+  return `github:originate/create-originate-app/template#${branch_name}`
 }
 
 export async function copyTemplate(
   targetDir: string,
   branch_name: string,
 ): Promise<void> {
-  const template_path = getTemplatePath(branch_name)
+  const template_path = getTemplateUri(branch_name)
 
   try {
     const emitter = degit(template_path, {


### PR DESCRIPTION
The CLI is looking up the current branch when it runs, which causes an error because usually the user is not in a git project directory when they run the CLI. With this change we assume that the desired template branch name is "master" except when specified otherwise in tests.